### PR TITLE
Update automated installs to reflect centos only

### DIFF
--- a/content/install_guide/automated_install/_index.md
+++ b/content/install_guide/automated_install/_index.md
@@ -7,7 +7,7 @@ weight = 25
 Automated Eucalytpus installation uses an [Ansible](https://www.ansible.com/overview/how-ansible-works) playbook.
 
 {{% notice note %}}
-Before starting the automated installation CentOS or RHEL 7.9 should be installed on all hosts.
+Before starting the automated installation CentOS 7.9 should be installed on all hosts. RHEL is not currently supported for automated installs.
 {{% /notice %}}
 
 To install Eucalyptus you will need to have Ansible and the Eucalyptus playbooks available and to create an *inventory* file that describes your deployment.


### PR DESCRIPTION
Automated install should state that RHEL is not supported, only CentOS.